### PR TITLE
Fix <div type="images"> in Smog.xml

### DIFF
--- a/articles/Smog.xml
+++ b/articles/Smog.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
-	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>
@@ -53,14 +52,14 @@
          </div>
          
          <div type="images">
+         	
             <figure xml:id="fig1">
                <graphic url="../images/smog1.jpg"./>
                <head></head>
                <note type="attribution">Chip Jacobs, 2008. Image courtesy of UCLA Library Special Collections</note>
                <figDesc></figDesc>
             </figure>
-            
-         <div type="images">
+       
             <figure xml:id="fig2">
                <graphic url="../images/smog2.jpg"./>
                <head></head>


### PR DESCRIPTION
I made a few changes that should help your page load. You had the <div type="images"> line in the document twice - there should only be one <div type="images"> element surrounding all of the <figure> elements. Also, you will need to **delete the smog2.xml file that you created as well as delete "smog2.xml" from the config -> site.json file**.
